### PR TITLE
fixed two typos

### DIFF
--- a/diffphys.md
+++ b/diffphys.md
@@ -10,7 +10,7 @@ The central goal of these methods is to use existing numerical solvers, and equi
 them with functionality to compute gradients with respect to their inputs.
 Once this is realized for all operators of a simulation, we can leverage 
 the autodiff functionality of DL frameworks with backpropagation to let gradient 
-information flow from from a simulator into an NN and vice versa. This has numerous 
+information flow from a simulator into an NN and vice versa. This has numerous 
 advantages such as improved learning feedback and generalization, as we'll outline below.
 
 In contrast to physics-informed loss functions, it also enables handling more complex

--- a/overview-ns-forw.ipynb
+++ b/overview-ns-forw.ipynb
@@ -117,7 +117,7 @@
    "source": [
     "def step(velocity, smoke, pressure, dt=1.0, buoyancy_factor=1.0):\n",
     "    smoke = advect.semi_lagrangian(smoke, velocity, dt) + INFLOW\n",
-    "    buoyancy_force = smoke * (0, buoyancy_factor) >> velocity  # resamples smoke to velocity sample points\n",
+    "    buoyancy_force = (smoke * (0, buoyancy_factor)).at(velocity)  # resamples smoke to velocity sample points\n",
     "    velocity = advect.semi_lagrangian(velocity, velocity, dt) + dt * buoyancy_force\n",
     "    velocity = diffuse.explicit(velocity, NU, dt)\n",
     "    velocity, pressure = fluid.make_incompressible(velocity)\n",


### PR DESCRIPTION
The `>>` operator did work as [`at()` method](https://tum-pbs.github.io/PhiFlow/phi/field/#phi.field.Field.at) in Colab. 