### PR TITLE
Small updates to intro-teaser.ipynb

### DIFF
--- a/intro-teaser.ipynb
+++ b/intro-teaser.ipynb
@@ -134,7 +134,7 @@
     "# Neural network\n",
     "act = tf.keras.layers.ReLU()\n",
     "nn_sv = tf.keras.models.Sequential([\n",
-    "  tf.keras.layers.Dense(10, activation=act),\n",
+    "  tf.keras.layers.Dense(10, activation=act, input_shape=(1,)),\n",
     "  tf.keras.layers.Dense(10, activation=act),\n",
     "  tf.keras.layers.Dense(1,activation='linear')])"
    ]
@@ -264,7 +264,7 @@
     "\n",
     "# Model\n",
     "nn_dp = tf.keras.models.Sequential([\n",
-    "  tf.keras.layers.Dense(10, activation=act),\n",
+    "  tf.keras.layers.Dense(10, activation=act, input_shape=(1,)),\n",
     "  tf.keras.layers.Dense(10, activation=act),\n",
     "  tf.keras.layers.Dense(1, activation='linear')])"
    ]

--- a/intro-teaser.ipynb
+++ b/intro-teaser.ipynb
@@ -173,7 +173,7 @@
    "source": [
     "# Loss function\n",
     "loss_sv = tf.keras.losses.MeanSquaredError()\n",
-    "optimizer_sv = tf.keras.optimizers.Adam(lr=0.001)\n",
+    "optimizer_sv = tf.keras.optimizers.Adam(learning_rate=0.001)\n",
     "nn_sv.compile(optimizer=optimizer_sv, loss=loss_sv)\n",
     "\n",
     "# Training\n",
@@ -291,7 +291,7 @@
     "def loss_dp(y_true, y_pred):\n",
     "    return mse(y_true,y_pred**2)\n",
     "\n",
-    "optimizer_dp = tf.keras.optimizers.Adam(lr=0.001)\n",
+    "optimizer_dp = tf.keras.optimizers.Adam(learning_rate=0.001)\n",
     "nn_dp.compile(optimizer=optimizer_dp, loss=loss_dp)"
    ]
   },


### PR DESCRIPTION
This fixes the error: `Input 0 of layer "dense" is incompatible with the layer: expected min_ndim=2, found ndim=1. Full shape received: (5,)`, which makes the current example code not run.

Passing the `input_shape` argument to the Dense layer, keras will create an input layer to insert before the current layer. This is equivalent to explicitly defining an InputLayer.

